### PR TITLE
bug in Table.delete 

### DIFF
--- a/mcpluginbase/src/main/java/com/bubladecoding/mcpluginbase/database/Table.java
+++ b/mcpluginbase/src/main/java/com/bubladecoding/mcpluginbase/database/Table.java
@@ -279,7 +279,7 @@ public abstract class Table<T extends IDed<I>, I extends  ConstantDesc> {
      * @return Whether anything has been deleted.
      */
     public boolean delete(I idValue) {
-        return deleteWhere(idField.dbName + " ?", idValue);
+        return deleteWhere(idField.dbName + " = ?", idValue);
     }
 
     /**


### PR DESCRIPTION
Missing a `=` so the delete function doesn't work
https://github.com/Bublade/mcpluginbase/blob/195af159f623227ade4cda357f48d9cb646e9d54/mcpluginbase/src/main/java/com/bubladecoding/mcpluginbase/database/Table.java#L282